### PR TITLE
Fix code in README and add types for PanZoomConfigOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ import { PanZoomConfig, PanZoomAPI, PanZoomModel } from 'ng2-panzoom';
 
     <div style="position: absolute; top: 100px; bottom: 0; left: 0; right: 0;">
 
-      <pan-zoom [config]="panzoomConfig">
+      <pan-zoom [config]="panZoomConfig">
 
         <div style="position: relative;">
 
@@ -111,16 +111,17 @@ import { PanZoomConfig, PanZoomAPI, PanZoomModel } from 'ng2-panzoom';
 
 export class MyComponent {
   ...
-  private panZoomConfig: PanZoomConfig = new PanZoomConfig;
+  panZoomConfig: PanZoomConfig = new PanZoomConfig();
   ...
 }
 ```
 
 ## Configuration
+
 You must first create and then pass in a configuration object (of type *PanZoomConfig*) via the `config` input property.  This configuration object also contains RXJS Observables which can be used to work with the API and also observe changes to the panzoom view.
 
 ```typescript
-private panZoomConfig: PanZoomConfig = new PanZoomConfig;
+panZoomConfig: PanZoomConfig = new PanZoomConfig();
 ```
 
 The following attributes are defined:
@@ -155,6 +156,7 @@ noDragFromElementClass              | string    | null              | If set, th
 acceleratePan                       | boolean   | true              | Controls whether the pan frame will be hardware accelerated.
 
 ## API
+
 The panzoom library provides an API for interacting with, observing, and controlling it.  The following methods and objects are available from the PanZoomAPI:
 
   - `model: PanZoomModel`  - The current panzoom model - see the _PanZoomModel_ Interface below.
@@ -232,7 +234,7 @@ import { Subscription } from 'rxjs';
 
 export class MyComponent implements OnInit, OnDestroy {
  
-  private panZoomConfig: PanZoomConfig = new PanZoomConfig;
+  panZoomConfig: PanZoomConfig = new PanZoomConfig();
   private panZoomAPI: PanZoomAPI;
   private apiSubscription: Subscription;
 
@@ -268,7 +270,7 @@ import { PanZoomConfig, PanZoomAPI, PanZoomModel } from 'ng2-panzoom';
 
 export class MyComponent implements OnInit, OnDestroy {
  
-  private panZoomConfig: PanZoomConfig = new PanZoomConfig;
+  panZoomConfig: PanZoomConfig = new PanZoomConfig();
   private modelChangedSubscription: Subscription;
 
   ngOnInit(): void {

--- a/projects/ng2-panzoom/src/lib/panzoom-config.ts
+++ b/projects/ng2-panzoom/src/lib/panzoom-config.ts
@@ -2,9 +2,9 @@ import { BehaviorSubject } from 'rxjs';
 import { Rect } from './types/rect';
 import { PanZoomModel } from './panzoom-model';
 import { PanZoomAPI } from './panzoom-api';
+import { PanZoomConfigOptions } from './types/pan-zoom-config-options';
 
 export class PanZoomConfig {
-
   zoomLevels = 5;
   neutralZoomLevel = 2;
   scalePerZoomLevel = 2.0;
@@ -58,11 +58,10 @@ export class PanZoomConfig {
     centerBottomLeft: null,
     centerBottomRight: null
   });
-  acceleratePan: true;
+  acceleratePan = true;
 
 
-
-  constructor(options?) {
+  constructor(options?: PanZoomConfigOptions) {
     if (options === undefined) {
       return;
     }

--- a/projects/ng2-panzoom/src/lib/types/pan-zoom-config-options.ts
+++ b/projects/ng2-panzoom/src/lib/types/pan-zoom-config-options.ts
@@ -1,0 +1,33 @@
+import {Rect} from './rect';
+import {BehaviorSubject} from 'rxjs';
+import {PanZoomModel} from '../panzoom-model';
+import {PanZoomAPI} from '../panzoom-api';
+
+export interface PanZoomConfigOptions {
+  zoomLevels?: number;
+  neutralZoomLevel?: number;
+  scalePerZoomLevel?: number;
+  initialZoomLevel?: number;
+  friction?: number;
+  haltSpeed?: number;
+  initialPanX?: number;
+  initialPanY?: number;
+  initialZoomToFit?: Rect;
+  keepInBounds?: boolean;
+  keepInBoundsDragPullback?: number;
+  keepInBoundsRestoreForce?: number;
+  panOnClickDrag?: boolean;
+  dragMouseButton?: 'left' | 'middle' | 'right'; // left, middle, right
+  zoomButtonIncrement?: number;
+  zoomOnDoubleClick?: boolean;
+  zoomOnMouseWheel?: boolean;
+  invertMouseWheel?: boolean;
+  zoomStepDuration?: number;
+  zoomToFitZoomLevelFactor?: number;
+  freeMouseWheel?: boolean;
+  freeMouseWheelFactor?: number;
+  noDragFromElementClass?: string;
+  modelChanged?: BehaviorSubject<PanZoomModel>;
+  api?: BehaviorSubject<PanZoomAPI>;
+  acceleratePan?: boolean;
+}


### PR DESCRIPTION
Hello,
This PR fix some code snippets that don't work out of the box in the README, and adds an interface to the PanZoomConfig options parameters.

I haven't tested thoroughly the types as I'm new to the development of Angular libraries, so this would probably need testing in a few projects before merging. Works fine for me and my Webstorm nevertheless!