### PR TITLE
Added panEnded event

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ dynamicContentDimensions                       | boolean   | false              
 
 ## Events
 
-- `panEnded` - Emits when the animation for a pan has ended
+- `panEnded(point: Point)` - Emits when the animation for a pan has ended
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -166,10 +166,14 @@ modelChanged                        | BehaviorSubject&lt;PanZoomModel>      | No
 keepInBounds                        | boolean   | false             | When true, it will not be possible to pan the contents off the screen -- it will snap back when trying to do so.  It will not be possible to zoom further out than the neutral zoom level.  *REMEMBER* that the initial zoom level must either be less than or equal to the neutral zoom level, or weird things will happen.
 keepInBoundsRestoreForce            | number    | 0.5               | Constant to control how quickly the contents snap back into place after attempting to pan out of bounds.
 keepInBoundsDragPullback            | number    | 0.7               | Constant to control the perceived force preventing dragging the contents out of bounds.
-dragMouseButton                     | string    | 'left'            | Controls which mouse button drags the view.  Valid options are `left`, `middle`, and `right`.  *NOTE:* Using `middle` and `right` will disable the default 'auxclick' and 'contextmenu' handlers, respectively.  *ALSO NOTE:* Chrome seems to have a bug that doesn't the permit the 'mousemove' event to fire after middle-click drag until it receives a normal left 'click' event.  If anyone can shed any light on this, I'd be happy to hear from you.  It's such an edge case, though, that I won't be opening a bug report, but feel free to do so if this affects you. 
+dragMouseButton                     | string    | 'left'            | Controls which mouse button drags the view.  Valid options are `left`, `middle`, and `right`.  *NOTE:* Using `middle` and `right` will disable the default 'auxclick' and 'contextmenu' handlers, respectively.  *ALSO NOTE:* Chrome seems to have a bug that doesn't the permit the 'mousemove' event to fire after middle-click drag until it receives a normal left 'click' event.  If anyone can shed any light on this, I'd be happy to hear from you.  It's such an edge case, though, that I won't be opening a bug report, but feel free to do so if this affects you.
 noDragFromElementClass              | string    | null              | If set, this will prevent click-drag on elements who have a parent element containing a specific class name.
 acceleratePan                       | boolean   | true              | Controls whether the pan frame will be hardware accelerated.
 dynamicContentDimensions                       | boolean   | false              | If true, a ResizeObserver will be used to detect changes in the content dimensions.  Useful if the content dimensions can't be predicted.  Alternatively, the API methods `detectContentDimensions()` or `contentDimensionsChanged()` can also be used.  ResizeObservers may not work in some older or mobile web browsers.  See https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver for info on browser compatibility.
+
+## Events
+
+- `panEnded` - Emits when the animation for a pan has ended
 
 ## API
 
@@ -186,11 +190,11 @@ The panzoom library provides an API for interacting with, observing, and control
    - `zoomOut(zoomType: 'lastPoint' | 'viewCenter' = 'lastPoint')` - This will zoom the view out from either the last zoomed point (if _lastPoint_), or from the centre point of the view (_viewCenter_), by one zoom level.  The default zoomType is `lastPoint`.
 
   - `zoomToFit(rectangle: Rect, [duration: number])` - Animates the view to focus on a rectangle of the underlying canvas.  **duration** is how long the animation should take (in seconds), and is optional.  **rectangle** is two coordinates on the canvas which the panZoom view is pan/zooming.  See the below section on PanZoom Interfaces for its definition.
- 
+
   - `resetView()` - A shortcut method to reset the pan and zoom back to the initial view.
-  
+
   - `getViewPosition(modelPosition: Point)` - By passing in x,y coordinates of the original, untransformed content canvas, it will return the current pixel position of this point.
-  
+
   - `getModelPosition(viewPosition: Point)` - The reverse operation of getViewPosition().
 
   - `panToPoint(point: Point, [duration: number])` - Will animate the view so that the centre point of the view is at the *point* parameter coordinates, relative to the original, unzoomed content width and height.
@@ -198,7 +202,7 @@ The panzoom library provides an API for interacting with, observing, and control
   - `panDelta(delta: Point, [duration: number])` - Will pan the view left, right, up, or down, based on a number of pixels relative to the original, unzoomed content.
 
   - `panDeltaPercent(deltaPercent: Point, [duration: number])` - Will pan the view up, down, left, or right, based on a percentage of the original, unzoomed content width and height.
-  
+
   - `panDeltaAbsolute(delta: Point, [duration: number])` - Will pan the view left, right, up, or down, based on a number of pixels.  This method doesn't adjust for scale.  I'm not sure why you'd want this, but it's provided just in case.
 
   - `centerContent([duration: number])` - Will centre the the content vertically and horizontally at the current scale.
@@ -253,7 +257,7 @@ import { Subscription } from 'rxjs';
 @Component({ ... })
 
 export class MyComponent implements OnInit, OnDestroy {
- 
+
   panZoomConfig: PanZoomConfig = new PanZoomConfig();
   private panZoomAPI: PanZoomAPI;
   private apiSubscription: Subscription;
@@ -289,7 +293,7 @@ import { PanZoomConfig, PanZoomAPI, PanZoomModel } from 'ngx-panzoom';
 @Component({ ... })
 
 export class MyComponent implements OnInit, OnDestroy {
- 
+
   panZoomConfig: PanZoomConfig = new PanZoomConfig();
   private modelChangedSubscription: Subscription;
 

--- a/projects/ngx-panzoom/src/lib/panzoom.component.ts
+++ b/projects/ngx-panzoom/src/lib/panzoom.component.ts
@@ -355,8 +355,7 @@ export class PanZoomComponent implements OnInit, AfterViewInit, OnDestroy {
         };
         this.lastMouseEventTime = event.timeStamp;
         this.isDragging = true;
-        // this.model.isPanning = false;
-        this.stopPanning(this.model.pan);
+        this.model.isPanning = false;
 
         if (this.isMobile) {
           this.zone.runOutsideAngular( () => document.addEventListener('touchend', this.onTouchEnd, false ) ); // leave this on document
@@ -370,12 +369,6 @@ export class PanZoomComponent implements OnInit, AfterViewInit, OnDestroy {
 
       return false;
     }
-  }
-
-
-  private stopPanning(point: Point) {
-    this.model.isPanning = false;
-    this.panEnded.emit(point);
   }
 
 
@@ -570,8 +563,7 @@ export class PanZoomComponent implements OnInit, AfterViewInit, OnDestroy {
     else {
       this.panVelocity = undefined;
       this.dragFinishing = false;
-      // this.model.isPanning = false;
-      this.stopPanning(this.model.pan);
+      this.model.isPanning = false;
       this.config.modelChanged.next(this.model);
       this.syncBaseToModel();
     }
@@ -747,8 +739,8 @@ export class PanZoomComponent implements OnInit, AfterViewInit, OnDestroy {
     else {
       // Animation has ended
       if (this.model.isPanning) {
-        // this.model.isPanning = false;
-        this.stopPanning(this.model.pan);
+        this.model.isPanning = false;
+        this.panEnded.next(this.model.pan);
       }
       this.syncBaseToModel();
       this.config.modelChanged.next(this.model);

--- a/projects/ngx-panzoom/src/lib/panzoom.component.ts
+++ b/projects/ngx-panzoom/src/lib/panzoom.component.ts
@@ -46,7 +46,7 @@ export class PanZoomComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('panzoomOverlay', { static: true }) private panzoomOverlayRef: ElementRef;
 
   @Input() private config: PanZoomConfig;
-  @Output() panEnded = new EventEmitter();
+  @Output() panEnded = new EventEmitter<Point>();
 
   private base: PanZoomModel; // this is what the pan/zoom view is before a zoom animation begins and after it ends.  It also updates with every mouse drag or freeZoom, but the animation is mostly tied to the model.
   private model: PanZoomModel; // this is used for incremental changes to the pan/zoom view during each animation frame.  Setting it will update the pan/zoom coordinates on the next call to updateDOM().  Not used during mouse drag.


### PR DESCRIPTION
This solves a problem I had when it comes to listening for pan events and reacting to it. Instead of having to manually poll for the current position I added an Output that runs when the animation is done, therefore only triggering once rather than 3 times if I do it wherever `this.model.isPanning = false` occurs in the code.